### PR TITLE
Add vitest tests for cn utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,5 +98,14 @@ pnpm --filter app-astra-components dev
 ```
 
 
+## 🧪 Tests
+
+Para ejecutar las pruebas del paquete `core-react`:
+
+```bash
+pnpm --filter @astrahub/core-react test
+```
+
+
 🤝 Créditos
 Desarrollado por Astrahub

--- a/packages/core-react/package.json
+++ b/packages/core-react/package.json
@@ -8,7 +8,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "test": "vitest run"
   },
   "sideEffects": false,
   "publishConfig": {
@@ -22,7 +23,8 @@
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
     "tsup": "^7.2.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.4"
   },
   "dependencies": {
     "@astrahub/themes": "^0.1.0",

--- a/packages/core-react/test/cn.test.ts
+++ b/packages/core-react/test/cn.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from '../src/utils/cn'
+
+describe('cn', () => {
+  it('combina clases básicas', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+  })
+
+  it('fusiona utilidades de Tailwind', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+})


### PR DESCRIPTION
## Summary
- add vitest dev dependency and test script for `core-react`
- create `cn.test.ts` checking class merging
- document how to run the tests in README

## Testing
- `pnpm --filter @astrahub/core-react test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c15edd8083258f6ef63cb926e5fb